### PR TITLE
Make sure to add teleop_twist_keyboard to ament index.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
+from ament_python.data_files import get_data_files
 from ament_python.script_dir import install_scripts_to_libexec
 from setuptools import setup
 
 package_name = 'teleop_twist_keyboard'
+data_files = get_data_files(package_name)
 install_scripts_to_libexec(package_name)
 
 setup(
@@ -11,6 +13,7 @@ setup(
     py_modules=[
         'teleop_twist_keyboard'
     ],
+    data_files=data_files,
     install_requires=['setuptools'],
     maintainer='Austin Hendrix',
     maintainer_email='namniart@gmail.com',


### PR DESCRIPTION
This ensures that this package is ros2 run-able, even in
a debian package.

I tested this by building a new debian package with this patch in it, installing it locally, and then ensuring that I could successfully execute `ros2 run teleop_twist_keyboard teleop_twist_keyboard`.

No CI since it won't really prove anything.

Fixes #4 