### PR TITLE
use ros2 run to launch whichever the installation used

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ Generic Keyboard Teleoperation for ROS
 
 ## Launch
 
-To run from Debian packages: `/opt/ros/r2b2/lib/teleop_twist_keyboard/teleop_twist_keyboard`
-
-To run in a from-source workspace: `ros2 run teleop_twist_keyboard teleop_twist_keyboard`
+To run: `ros2 run teleop_twist_keyboard teleop_twist_keyboard`
 
 ## Usage
 


### PR DESCRIPTION
To merge once https://github.com/ros2/teleop_twist_keyboard/pull/6 is released

Fixes #7 
Connects to #7 