### PR TITLE
Fix teleop_twist_keyboard to have a setup.cfg.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,6 @@
 
   <url type="website">http://wiki.ros.org/teleop_twist_keyboard</url>
 
-  <build_depend>ament_python</build_depend>
-
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/teleop_twist_keyboard
+[install]
+install-scripts=$base/lib/teleop_twist_keyboard

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
-from ament_python.data_files import get_data_files
-from ament_python.script_dir import install_scripts_to_libexec
 from setuptools import setup
 
 package_name = 'teleop_twist_keyboard'
-data_files = get_data_files(package_name)
-install_scripts_to_libexec(package_name)
 
 setup(
     name=package_name,
@@ -13,7 +9,11 @@ setup(
     py_modules=[
         'teleop_twist_keyboard'
     ],
-    data_files=data_files,
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('shared/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     maintainer='Austin Hendrix',
     maintainer_email='namniart@gmail.com',


### PR DESCRIPTION
This brings it inline with what the rest of the python
packages have converted to, and should make it build again.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

CI:
* TB2 amd64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=91)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/91/)