### PR TITLE
Add Windows support to teleop_twist_keyboard.

### DIFF
--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -31,7 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import select
 import sys
 
 import geometry_msgs.msg

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -104,10 +104,11 @@ speedBindings = {
 
 def getKey(settings):
     if sys.platform == 'win32':
-        key = chr(ord(msvcrt.getch()))
+        # getwch() returns a string on Windows
+        key = msvcrt.getwch()
     else:
         tty.setraw(sys.stdin.fileno())
-        select.select([sys.stdin], [], [], 0)
+        # sys.stdin.read() returns a string on Linux
         key = sys.stdin.read(1)
         termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
     return key

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -33,12 +33,16 @@
 
 import select
 import sys
-import termios
-import tty
 
-from geometry_msgs.msg import Twist
-
+import geometry_msgs.msg
 import rclpy
+
+if sys.platform == 'win32':
+    import msvcrt
+else:
+    import termios
+    import tty
+
 
 msg = """
 This node takes keypresses from the keyboard and publishes them
@@ -99,11 +103,26 @@ speedBindings = {
 
 
 def getKey(settings):
-    tty.setraw(sys.stdin.fileno())
-    select.select([sys.stdin], [], [], 0)
-    key = sys.stdin.read(1)
-    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+    if sys.platform == 'win32':
+        key = chr(ord(msvcrt.getch()))
+    else:
+        tty.setraw(sys.stdin.fileno())
+        select.select([sys.stdin], [], [], 0)
+        key = sys.stdin.read(1)
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
     return key
+
+
+def saveTerminalSettings():
+    if sys.platform == 'win32':
+        return None
+    return termios.tcgetattr(sys.stdin)
+
+
+def restoreTerminalSettings(old_settings):
+    if sys.platform == 'win32':
+        return
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
 
 
 def vels(speed, turn):
@@ -111,12 +130,12 @@ def vels(speed, turn):
 
 
 def main():
-    settings = termios.tcgetattr(sys.stdin)
+    settings = saveTerminalSettings()
 
     rclpy.init()
 
     node = rclpy.create_node('teleop_twist_keyboard')
-    pub = node.create_publisher(Twist, 'cmd_vel', 10)
+    pub = node.create_publisher(geometry_msgs.msg.Twist, 'cmd_vel', 10)
 
     speed = 0.5
     turn = 1.0
@@ -152,7 +171,7 @@ def main():
                 if (key == '\x03'):
                     break
 
-            twist = Twist()
+            twist = geometry_msgs.msg.Twist()
             twist.linear.x = x * speed
             twist.linear.y = y * speed
             twist.linear.z = z * speed
@@ -165,7 +184,7 @@ def main():
         print(e)
 
     finally:
-        twist = Twist()
+        twist = geometry_msgs.msg.Twist()
         twist.linear.x = 0.0
         twist.linear.y = 0.0
         twist.linear.z = 0.0
@@ -174,7 +193,7 @@ def main():
         twist.angular.z = 0.0
         pub.publish(twist)
 
-        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+        restoreTerminalSettings(settings)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based on the original code from ayushghosh21 in
https://github.com/ros2/teleop_twist_keyboard/pull/23 , but
fixed up to work on both Linux and Windows.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #20 