### PR TITLE
Switch to underscores for setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/teleop_twist_keyboard
+script_dir=$base/lib/teleop_twist_keyboard
 [install]
-install-scripts=$base/lib/teleop_twist_keyboard
+install_scripts=$base/lib/teleop_twist_keyboard


### PR DESCRIPTION
This avoids a warning on newer setuptools.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>