### PR TITLE
Added TwistStamped option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ e/c : increase/decrease only angular speed by 10%
 CTRL-C to quit
 ```
 
-# Twist with header
-Publishing a `TwistStamped` message instead of `Twist` can be enabled with the `stamped` parameter. Additionally the `frame_id` of the `TwistStamped` message can be set with the `frame_id` parameter.
-```
-ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r -p stamped:=True -p frame_id:="base_link"
+## Parameters
+- `stamped (bool, default: false)`
+  - If false (the default), publish a `geometry_msgs/msg/Twist` message.  If true, publish a `geometry_msgs/msg/TwistStamped` message.
+- `frame_id` (string, default: '')`
+  - When `stamped` is true, the frame_id to use when publishing the `geometry_msgs/msg/TwistStamped` message.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ e/c : increase/decrease only angular speed by 10%
 
 CTRL-C to quit
 ```
+
+# Twist with header
+Publishing a `TwistStamped` message instead of `Twist` can be enabled with the `stamped` parameter. Additionally the `frame_id` of the `TwistStamped` message can be set with the `frame_id` parameter.
+```
+ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r -p stamped:=True -p frame_id:="base_link"

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ CTRL-C to quit
 ## Parameters
 - `stamped (bool, default: false)`
   - If false (the default), publish a `geometry_msgs/msg/Twist` message.  If true, publish a `geometry_msgs/msg/TwistStamped` message.
-- `frame_id` (string, default: '')`
+- `frame_id (string, default: '')`
   - When `stamped` is true, the frame_id to use when publishing the `geometry_msgs/msg/TwistStamped` message.

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -137,11 +137,10 @@ def main():
     node = rclpy.create_node('teleop_twist_keyboard')
 
     # parameters
-    node.declare_parameter('stamped', False)
-    node.declare_parameter('frame_id', '')
-
-    stamped = node.get_parameter('stamped').value
-    frame_id = node.get_parameter('frame_id').value
+    stamped = node.declare_parameter('stamped', False)
+    frame_id = node.declare_parameter('frame_id', '')
+    if not stamped and frame_id:
+        raise Exception("'frame_id' can only be set when 'stamped' is True")
 
     if stamped:
         TwistMsg = geometry_msgs.msg.TwistStamped

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -35,6 +35,7 @@ import sys
 
 import geometry_msgs.msg
 import rclpy
+import threading
 
 if sys.platform == 'win32':
     import msvcrt
@@ -137,8 +138,8 @@ def main():
     node = rclpy.create_node('teleop_twist_keyboard')
 
     # parameters
-    stamped = node.declare_parameter('stamped', False)
-    frame_id = node.declare_parameter('frame_id', '')
+    stamped = node.declare_parameter('stamped', False).value
+    frame_id = node.declare_parameter('frame_id', '').value
     if not stamped and frame_id:
         raise Exception("'frame_id' can only be set when 'stamped' is True")
 
@@ -148,6 +149,9 @@ def main():
         TwistMsg = geometry_msgs.msg.Twist
 
     pub = node.create_publisher(TwistMsg, 'cmd_vel', 10)
+
+    spinner = threading.Thread(target=rclpy.spin, args=(node,))
+    spinner.start()
 
     speed = 0.5
     turn = 1.0
@@ -217,6 +221,8 @@ def main():
         twist.angular.y = 0.0
         twist.angular.z = 0.0
         pub.publish(twist_msg)
+        rclpy.shutdown()
+        spinner.join()
 
         restoreTerminalSettings(settings)
 


### PR DESCRIPTION
I was looking to use a TwistStamped output and noticed this wasn't an option. I saw a previous effort for the ROS1 package (https://github.com/ros-teleop/teleop_twist_keyboard/pull/30) and made a similar effort.