### PR TITLE
Reject parameter updates.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,11 +15,14 @@
   <author>Graylin Trevor Jay</author>
 
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
+  <test_depend>ament_xmllint</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -131,29 +131,6 @@ def vels(speed, turn):
     return 'currently:\tspeed %.2f\tturn %.2f ' % (speed, turn)
 
 
-def check_param_changes(parameter_list):
-    retval = rcl_interfaces.msg.SetParametersResult()
-    retval.successful = True
-    for param in parameter_list:
-        if param.name == 'stamped':
-            retval.successful = False
-            retval.reason = 'Cannot change stamped attribute at runtime'
-            break
-        elif param.name == 'frame_id':
-            retval.successful = False
-            retval.reason = 'Cannot change frame_id at runtime'
-            break
-        elif param.name == 'speed':
-            retval.successful = False
-            retval.reason = 'Cannot change speed at runtime with parameter (use the keyboard)'
-            break
-        elif param.name == 'turn':
-            retval.successful = False
-            retval.reason = 'Cannot change turn speed at runtime with parameter (use the keyboard)'
-
-    return retval
-
-
 def main():
     settings = saveTerminalSettings()
 
@@ -162,12 +139,11 @@ def main():
     node = rclpy.create_node('teleop_twist_keyboard')
 
     # parameters
-    stamped = node.declare_parameter('stamped', False).value
-    frame_id = node.declare_parameter('frame_id', '').value
-    speed = node.declare_parameter('speed', 0.5).value
-    turn = node.declare_parameter('turn', 1.0).value
-
-    node.add_on_set_parameters_callback(check_param_changes)
+    read_only_descriptor = rcl_interfaces.msg.ParameterDescriptor(read_only=True)
+    stamped = node.declare_parameter('stamped', False, read_only_descriptor).value
+    frame_id = node.declare_parameter('frame_id', '', read_only_descriptor).value
+    speed = node.declare_parameter('speed', 0.5, read_only_descriptor).value
+    turn = node.declare_parameter('turn', 1.0, read_only_descriptor).value
 
     if not stamped and frame_id:
         raise Exception("'frame_id' can only be set when 'stamped' is True")

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -35,6 +35,7 @@ import sys
 import threading
 
 import geometry_msgs.msg
+import rcl_interfaces.msg
 import rclpy
 
 if sys.platform == 'win32':
@@ -127,7 +128,30 @@ def restoreTerminalSettings(old_settings):
 
 
 def vels(speed, turn):
-    return 'currently:\tspeed %s\tturn %s ' % (speed, turn)
+    return 'currently:\tspeed %.2f\tturn %.2f ' % (speed, turn)
+
+
+def check_param_changes(parameter_list):
+    retval = rcl_interfaces.msg.SetParametersResult()
+    retval.successful = True
+    for param in parameter_list:
+        if param.name == 'stamped':
+            retval.successful = False
+            retval.reason = 'Cannot change stamped attribute at runtime'
+            break
+        elif param.name == 'frame_id':
+            retval.successful = False
+            retval.reason = 'Cannot change frame_id at runtime'
+            break
+        elif param.name == 'speed':
+            retval.successful = False
+            retval.reason = 'Cannot change speed at runtime with parameter (use the keyboard)'
+            break
+        elif param.name == 'turn':
+            retval.successful = False
+            retval.reason = 'Cannot change turn speed at runtime with parameter (use the keyboard)'
+
+    return retval
 
 
 def main():
@@ -142,6 +166,8 @@ def main():
     frame_id = node.declare_parameter('frame_id', '').value
     speed = node.declare_parameter('speed', 0.5).value
     turn = node.declare_parameter('turn', 1.0).value
+
+    node.add_on_set_parameters_callback(check_param_changes)
 
     if not stamped and frame_id:
         raise Exception("'frame_id' can only be set when 'stamped' is True")

--- a/test/test_xmllint.py
+++ b/test/test_xmllint.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from ament_xmllint.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.xmllint
+def test_xmllint() -> None:
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'


### PR DESCRIPTION
## Description

While there are a number of parameters here that can be set at startup, none of them can actually be configured at runtime successfully.  Explicitly reject them here.

### Is this user-facing behavior change?

Yes, in the fact that it explicitly fails setting parameters at runtime now.  Previously, the parameters could be successfully set at runtime, but they would have no actual effect on behavior.

### Did you use Generative AI?

No.

### Additional Information

