### PR TITLE
Don't publish twist while updating velocities

### DIFF
--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -191,6 +191,7 @@ def main():
                 if (status == 14):
                     print(msg)
                 status = (status + 1) % 15
+                continue
             else:
                 x = 0.0
                 y = 0.0


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
While updating velocities with the keys, the robot continues to move. Sometimes this behavior is unwanted and the user wants to update the velocities while keeping the robot stationary and only move the robot after the desired velocity update is done.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

After this simple fix, updating the velocities does not cause the robot to move during the update. However, if some users prefer to move the robot while updating velocities, then perhaps we could parameterize this using ros params.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
